### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/examples/picaso_sgc_demo/keywords.txt
+++ b/examples/picaso_sgc_demo/keywords.txt
@@ -6,22 +6,22 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-DisplayShield4d			KEYWORD1
+DisplayShield4d	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-Init		KEYWORD2
-Reset			KEYWORD2
-Clear			KEYWORD2
-GetReply		KEYWORD2
-get16bitRGB		KEYWORD2
-SetPenSize		KEYWORD2
-putpixel		KEYWORD2
-line			KEYWORD2
-rectangle		KEYWORD2
-circle			KEYWORD2
+Init	KEYWORD2
+Reset	KEYWORD2
+Clear	KEYWORD2
+GetReply	KEYWORD2
+get16bitRGB	KEYWORD2
+SetPenSize	KEYWORD2
+putpixel	KEYWORD2
+line	KEYWORD2
+rectangle	KEYWORD2
+circle	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords